### PR TITLE
Gjør Swagger-endepunkter tilgjengelig uten autentisering

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,13 +56,12 @@
             <artifactId>lombok-mapstruct-binding</artifactId>
             <version>0.2.0</version>
         </dependency>
-        <!-- Swagger/OpenAPI - Midlertidig fjernet for å få applikasjonen til å starte
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.2.0</version>
         </dependency>
-        -->
+
         <!-- PostgreSQL -->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/backend/src/main/java/com/nag/SecurityConfig.java
+++ b/backend/src/main/java/com/nag/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.nag;
 
 // Ja, den skal ligge her og ikke i config.
 // Kristian
+// Hvorfor skal den ikke ligge i config-mappe, eller security? Gir ikke det bedre struktur og organisering?
 
 import com.nag.service.UserDetailsServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,13 +58,32 @@ public class SecurityConfig {
     }
 
     // Add filterchain method (Hinkula, p. 109)
+    /* Endret litt  for å få tilgang til Swagger, Mia.
+    La til tillatelse (permitAll) for Swagger-endepunktene i filterChain() for å sikre at Swagger UI
+    og API-dokumentasjonen er tilgjengelig uten autentisering.
+    Dette er nødvendig for testing av API-er og dokumentasjone  til rapporten uten å måtte logge inn.
+     */
+
+    /**
+     *
+     * @param http HttpSecurity-objektet som brukes til å konfigurere sikkerhet
+     * @return Den ferdigbygde SecurityFilterChain som håndterer sikkerheten
+     * @throws Exception Kan kastes ved konfigurasjinsfeil i sikkerhet.
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf((csrf) -> csrf.disable())
                 .cors(withDefaults())
                 .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorizeHttpRequests) ->
-                        authorizeHttpRequests.requestMatchers(HttpMethod.POST, "/login").permitAll().anyRequest().authenticated()).addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class).exceptionHandling((exceptionHandling) -> exceptionHandling.authenticationEntryPoint(exceptionHandler));
+                        authorizeHttpRequests.requestMatchers(HttpMethod.POST, "/login").permitAll()
+                                .requestMatchers(
+                                        "/v3/api-docs/**",
+                                        "/swagger-ui/**",
+                                        "/swagger-ui.html"
+
+                                ). permitAll().anyRequest().authenticated()
+                ).addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class).exceptionHandling((exceptionHandling) -> exceptionHandling.authenticationEntryPoint(exceptionHandler));
 
 
         return http.build();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.password=123
 
 # Hibernate config
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-# ddl-auto satt til create for testing av authentication (kjørefeil ved update når man kjører to ganger på rad)
+# ddl-auto satt til create for testing av authentication (kjorefeil ved update nor man kjorer to ganger paa rad)
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 


### PR DESCRIPTION
Gjør Swagger-endepunkter tilgjengelig uten autentisering i sikkerhetskonfigurasjonen

- Tillater offentlig tilgang til Swagger-endepunkter (/v3/api-docs/**, /swagger-ui/**, /swagger-ui.html)
- Endret spesialtegn i application.properties som gav feil ved bygging.
- Har testet og kjørt systemet, funker fint etter endringene.